### PR TITLE
Fazer o workflow de deploy só ser ativado quando o push for na master

### DIFF
--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy para ambiente de test
 on:
   push:
     branches:
-      - '**'
+      - master
     paths:
       - 'src/**'
       - 'docker-compose.yaml'


### PR DESCRIPTION
(para evitar código merda de ir para o servidor)